### PR TITLE
renamed transaction to wps-transaction

### DIFF
--- a/inc/class-wps-transaction.php
+++ b/inc/class-wps-transaction.php
@@ -22,7 +22,7 @@ require_once plugin_dir_path( __FILE__ ) . '/../inc/class-wps-form-exception.php
 /**
  * Represents one transaction on the system.
  */
-class Transaction extends WpRecord {
+class WPS_Transaction extends WpRecord {
 	/**
 	 * Initialize. Set up database fields.
 	 *

--- a/inc/wps-admin.php
+++ b/inc/wps-admin.php
@@ -41,7 +41,7 @@ function wps_transactions_page() {
 		display_template(
 			__DIR__ . '/../tpl/wps-transaction-detail.tpl.php',
 			array(
-				'transaction' => Transaction::findOne( get_req_var( 'transaction_detail' ) ),
+				'transaction' => WPS_Transaction::findOne( get_req_var( 'transaction_detail' ) ),
 				'user_display_by_id' => wps_user_display_by_id(),
 			)
 		);
@@ -102,7 +102,7 @@ function wps_transactions_page() {
 	}
 
 	if ( is_req_var( 'account' ) && get_req_var( 'account' ) ) {
-		$transactions = Transaction::findAllByQuery(
+		$transactions = WPS_Transaction::findAllByQuery(
 			'SELECT   * ' .
 			'FROM     :table ' .
 			'WHERE    sender=%s ' .
@@ -112,7 +112,7 @@ function wps_transactions_page() {
 			get_req_var( 'account' )
 		);
 	} else {
-		$transactions = Transaction::findAllByQuery(
+		$transactions = WPS_Transaction::findAllByQuery(
 			'SELECT   * ' .
 			'FROM      :table ' .
 			"ORDER BY  $order"
@@ -149,7 +149,7 @@ function wps_transactions_page() {
  * @throws WPS_Form_Exception If there is an error.
  */
 function wps_create_seeds_save() {
-	$t = new Transaction();
+	$t = new WPS_Transaction();
 	$t->receiver  = get_req_var( 'receiver' );
 	$t->amount    = get_req_var( 'amount' );
 	$t->performCreate();
@@ -162,7 +162,7 @@ function wps_create_seeds_save() {
  * @throws WPS_Form_Exception If there is an error.
  */
 function wps_burn_seeds_save() {
-	$t = new Transaction();
+	$t = new WPS_Transaction();
 	$t->sender    = get_req_var( 'sender' );
 	$t->amount    = get_req_var( 'amount' );
 	$t->performBurn();
@@ -201,7 +201,7 @@ function wps_settings_page() {
  * Save the transaction.
  */
 function wps_new_transaction_save() {
-	$t = new Transaction();
+	$t = new WPS_Transaction();
 	$t->sender    = get_req_var( 'sender' );
 	$t->receiver  = get_req_var( 'receiver' );
 	$t->amount    = get_req_var( 'amount' );

--- a/inc/wps-public.php
+++ b/inc/wps-public.php
@@ -175,7 +175,7 @@ function wps_history_sc( $args ) {
 	$user_display_by_id = wps_user_display_by_id();
 	$vars = array();
 	$vars['transactions'] = array();
-	$transactions         = Transaction::findAllByQuery(
+	$transactions         = WPS_Transaction::findAllByQuery(
 		'SELECT * ' .
 		'FROM   :table ' .
 		'WHERE  sender=%s ' .

--- a/wp-seeds.php
+++ b/wp-seeds.php
@@ -28,7 +28,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  */
-require_once plugin_dir_path( __FILE__ ) . '/inc/class-transaction.php';
+require_once plugin_dir_path( __FILE__ ) . '/inc/class-wps-transaction.php';
 require_once plugin_dir_path( __FILE__ ) . '/inc/class-custom-list-table.php';
 require_once plugin_dir_path( __FILE__ ) . '/inc/lib.php';
 require_once plugin_dir_path( __FILE__ ) . '/inc/class-wps-form-exception.php';
@@ -42,20 +42,19 @@ require_once plugin_dir_path( __FILE__ ) . '/inc/wps-public.php';
  * @return void
  */
 function wps_activate() {
-	Transaction::install();
+	WPS_Transaction::install();
 }
 register_activation_hook( __FILE__, 'wps_activate' );
 
 /**
- * Handle plugin deactivation.
+ * Handle plugin uninstall.
  *
  * @return void
  */
-function wps_deactivate() {
-	Transaction::uninstall();
+function wps_uninstall() {
+	WPS_Transaction::uninstall();
 }
-register_deactivation_hook( __FILE__, 'wps_deactivate' );
-
+register_uninstall_hook( __FILE__, 'wps_uninstall' );
 
 /**
  * Load styles.
@@ -358,7 +357,7 @@ add_shortcode( 'seeds-request', 'request_seeds_form_shortcode' );
  * @return void
  */
 function wps_send_seeds_form_process() {
-	$t = new Transaction();
+	$t = new WPS_Transaction();
 	$t->sender    = get_current_user_id();
 	$t->receiver  = get_req_var( 'receiver' );
 	$t->amount    = get_req_var( 'amount' );


### PR DESCRIPTION
and made the database table removal happen on uninstall rather than deactivation.

fixes #121 